### PR TITLE
Laravel scaffold agent for CRUD generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+vendor/
+composer.lock
+.phpunit.result.cache
+.php_cs.cache
+.idea/
+.php-cs-fixer.cache

--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
-# AI-Agents-Collection
-This repository contains examples of AI agents built using OpenAI, LangChain, and integrated in Cursor. Each agent performs specific tasks such as code explanation, debugging, API testing, and more.
+# Laravel Scaffold Agent
+
+Generate full CRUD modules (Models, Migrations, Controllers, Routes, Views) from a natural language prompt.
+
+## Installation
+
+Add to an existing Laravel app (v10 or v11):
+
+1. Require via path or VCS:
+
+```bash
+composer config repositories.scaffold-agent path /workspace
+composer require acme/laravel-scaffold-agent:dev-main
+```
+
+2. The service provider auto-registers via package discovery. If disabled, add to `config/app.php` providers:
+
+```php
+Acme\ScaffoldAgent\ScaffoldAgentServiceProvider::class,
+```
+
+## Usage
+
+Prompt-driven generation:
+
+```bash
+php artisan scaffold:module "Create a blog module with title, content:text, published_at:datetime"
+```
+
+Or explicit options:
+
+```bash
+php artisan scaffold:module --name=Blog --fields=title:string,content:text,published_at:datetime
+```
+
+Options:
+- `--api`: Generate API controller and register `Route::apiResource` in `routes/api.php`
+- `--force`: Overwrite existing files
+
+This will generate:
+- `app/Models/Blog.php`
+- `database/migrations/*_create_blogs_table.php`
+- `app/Http/Controllers/BlogController.php`
+- Routes in `routes/web.php` (or `routes/api.php` with `--api`)
+- Views in `resources/views/blog/` (index, create, edit, show) for web mode
+
+Then run migrations:
+
+```bash
+php artisan migrate
+```
+
+## LLM-assisted parsing (optional)
+If `OPENAI_API_KEY` is set, the command will call OpenAI to parse the prompt. Otherwise it falls back to heuristics.
+
+Environment variables:
+- `OPENAI_API_KEY`
+- `OPENAI_MODEL` (default `gpt-4o-mini`)
+
+## Notes
+- Fields ending with `_id` become `unsignedBigInteger` columns.
+- Fields ending with `_at` become `datetime`.
+- Common names like `content`/`body`/`description` default to `text`.
+
+## Example
+
+```bash
+php artisan scaffold:module "Create a product module with name, description:text, price:decimal, is_active:boolean, published_at"
+```
+
+## License
+MIT

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+  "name": "acme/laravel-scaffold-agent",
+  "description": "Artisan command to generate CRUD modules from natural language prompts.",
+  "type": "library",
+  "license": "MIT",
+  "require": {
+    "php": ">=8.1",
+    "illuminate/support": "^10.0 || ^11.0",
+    "illuminate/filesystem": "^10.0 || ^11.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\ScaffoldAgent\\": "src/"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Acme\\ScaffoldAgent\\ScaffoldAgentServiceProvider"
+      ]
+    }
+  }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Package Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Console/ScaffoldModuleCommand.php
+++ b/src/Console/ScaffoldModuleCommand.php
@@ -1,0 +1,425 @@
+<?php
+
+namespace Acme\ScaffoldAgent\Console;
+
+use Acme\ScaffoldAgent\Support\FileWriter;
+use Acme\ScaffoldAgent\Support\NameInflector;
+use Acme\ScaffoldAgent\Support\PromptParser;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class ScaffoldModuleCommand extends Command
+{
+    protected $signature = 'scaffold:module
+        {prompt?* : Natural language prompt, e.g., "Create a blog module with title, content, published_at"}
+        {--name= : Explicit module name (overrides parsed)}
+        {--fields= : Comma-separated fields with optional types, e.g., title:string,content:text,published_at:datetime}
+        {--force : Overwrite existing files}
+        {--api : Generate API controller and routes (uses routes/api.php)}';
+
+    protected $description = 'Generate a full CRUD module (Model, Migration, Controller, Routes, Views) from a natural language prompt.';
+
+    public function handle(): int
+    {
+        $prompt = trim(implode(' ', $this->argument('prompt') ?? []));
+        $explicitName = $this->option('name');
+        $explicitFields = $this->option('fields');
+        $force = (bool) $this->option('force');
+        $isApi = (bool) $this->option('api');
+
+        if ($prompt === '' && !$explicitName && !$explicitFields) {
+            $this->error('Provide a prompt or --name and --fields.');
+            return self::INVALID;
+        }
+
+        $parser = new PromptParser();
+        $spec = $parser->parse($prompt, [
+            'name' => $explicitName,
+            'fields' => $explicitFields,
+        ]);
+
+        if (!$spec || empty($spec['name']) || empty($spec['fields'])) {
+            $this->error('Could not parse the prompt/options into a module spec.');
+            return self::INVALID;
+        }
+
+        $inflector = new NameInflector($spec['name']);
+        $names = $inflector->toArray();
+
+        $this->line('Module: <info>'.$names['modelName'].'</info>');
+        $this->line('Table: <info>'.$names['tableName'].'</info>');
+        $this->line('Fields: <info>'.implode(', ', array_map(fn($f) => $f['name'].':'.$f['type'], $spec['fields'])).'</info>');
+
+        $writer = new FileWriter($this->laravel->basePath());
+
+        // Generate Model
+        $this->generateModel($writer, $names, $spec['fields'], $force);
+
+        // Generate Migration
+        $this->generateMigration($writer, $names, $spec['fields'], $force);
+
+        // Generate Controller
+        $this->generateController($writer, $names, $spec['fields'], $force, $isApi);
+
+        // Generate Views (only for web)
+        if (!$isApi) {
+            $this->generateViews($writer, $names, $spec['fields'], $force);
+        }
+
+        // Update Routes
+        $this->updateRoutes($writer, $names, $isApi);
+
+        $this->info('Scaffold complete. Run migrations with: php artisan migrate');
+
+        return self::SUCCESS;
+    }
+
+    private function generateModel(FileWriter $writer, array $names, array $fields, bool $force): void
+    {
+        $fillable = array_map(fn($f) => "'{$f['name']}'", $fields);
+        $casts = [];
+        foreach ($fields as $field) {
+            $type = $field['type'];
+            if (in_array($type, ['datetime', 'timestamp', 'date'])) {
+                $casts[] = "'{$field['name']}' => '{$type}'";
+            } elseif (in_array($type, ['boolean'])) {
+                $casts[] = "'{$field['name']}' => 'boolean'";
+            }
+        }
+
+        $castsBlock = empty($casts) ? '' : "\n    protected $casts = [\n        ".implode(",\n        ", $casts)."\n    ];\n";
+
+        $modelContent = <<<PHP
+<?php
+
+namespace App\\Models;
+
+use Illuminate\\Database\\Eloquent\\Factories\\HasFactory;
+use Illuminate\\Database\\Eloquent\\Model;
+
+class {$names['modelName']} extends Model
+{
+    use HasFactory;
+
+    protected \$fillable = [
+        {$this->implodeIndented($fillable)}
+    ];
+{$castsBlock}}
+PHP;
+
+        $path = 'app/Models/'.$names['modelName'].'.php';
+        $writer->write($path, $modelContent, $force);
+        $this->info('Model created: '.$path);
+    }
+
+    private function generateMigration(FileWriter $writer, array $names, array $fields, bool $force): void
+    {
+        $timestamp = date('Y_m_d_His');
+        $filename = $timestamp.'_create_'.$names['tableName'].'_table.php';
+        $path = 'database/migrations/'.$filename;
+
+        $columns = [];
+        foreach ($fields as $field) {
+            $columns[] = '            '.$this->columnForField($field);
+        }
+        $columns[] = '            $table->timestamps();';
+
+        $migration = <<<PHP
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('{$names['tableName']}', function (Blueprint $table) {
+            $table->id();
+{$this->implodeLines($columns)}
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('{$names['tableName']}');
+    }
+};
+PHP;
+
+        $writer->write($path, $migration, $force);
+        $this->info('Migration created: '.$path);
+    }
+
+    private function generateController(FileWriter $writer, array $names, array $fields, bool $force, bool $isApi): void
+    {
+        $validationRules = [];
+        foreach ($fields as $field) {
+            $validationRules[] = "            '{$field['name']}' => '".$this->validationForType($field['type'])."',";
+        }
+        $fillableAssign = [];
+        foreach ($fields as $field) {
+            $fillableAssign[] = "            '{$field['name']}' => \$request->input('{$field['name']}'),";
+        }
+
+        $paramVar = $names['singularSnake'];
+        $compactVar = $paramVar;
+
+        if ($isApi) {
+            $controllerContent = <<<PHP
+<?php
+
+namespace App\\Http\\Controllers;
+
+use App\\Models\\{$names['modelName']};
+use Illuminate\\Http\\Request;
+
+class {$names['controllerName']} extends Controller
+{
+    public function index()
+    {
+        return {$names['modelName']}::paginate();
+    }
+
+    public function store(Request $request)
+    {
+        \$validated = \$request->validate([
+{$this->implodeLines($validationRules)}
+        ]);
+
+        \${$paramVar} = {$names['modelName']}::create(\$validated);
+        return response()->json(\${$paramVar}, 201);
+    }
+
+    public function show({$names['modelName']} \${$paramVar})
+    {
+        return \$${paramVar};
+    }
+
+    public function update(Request \$request, {$names['modelName']} \${$paramVar})
+    {
+        \$validated = \$request->validate([
+{$this->implodeLines($validationRules)}
+        ]);
+
+        \$${$paramVar}->update(\$validated);
+        return \$${paramVar};
+    }
+
+    public function destroy({$names['modelName']} \${$paramVar})
+    {
+        \$${$paramVar}->delete();
+        return response()->noContent();
+    }
+}
+PHP;
+        } else {
+            $controllerContent = <<<PHP
+<?php
+
+namespace App\\Http\\Controllers;
+
+use App\\Models\\{$names['modelName']};
+use Illuminate\\Http\\Request;
+
+class {$names['controllerName']} extends Controller
+{
+    public function index()
+    {
+        \$items = {$names['modelName']}::latest()->paginate();
+        return view('{$names['viewDir']}.index', compact('items'));
+    }
+
+    public function create()
+    {
+        return view('{$names['viewDir']}.create');
+    }
+
+    public function store(Request \$request)
+    {
+        \$validated = \$request->validate([
+{$this->implodeLines($validationRules)}
+        ]);
+
+        {$names['modelName']}::create(\$validated);
+        return redirect()->route('{$names['routeName']}.index')->with('status', '{$names['modelName']} created');
+    }
+
+    public function show({$names['modelName']} \${$paramVar})
+    {
+        return view('{$names['viewDir']}.show', compact('{$compactVar}'));
+    }
+
+    public function edit({$names['modelName']} \${$paramVar})
+    {
+        return view('{$names['viewDir']}.edit', compact('{$compactVar}'));
+    }
+
+    public function update(Request \$request, {$names['modelName']} \${$paramVar})
+    {
+        \$validated = \$request->validate([
+{$this->implodeLines($validationRules)}
+        ]);
+
+        \$${$paramVar}->update(\$validated);
+        return redirect()->route('{$names['routeName']}.index')->with('status', '{$names['modelName']} updated');
+    }
+
+    public function destroy({$names['modelName']} \${$paramVar})
+    {
+        \$${$paramVar}->delete();
+        return redirect()->route('{$names['routeName']}.index')->with('status', '{$names['modelName']} deleted');
+    }
+}
+PHP;
+        }
+
+        $path = 'app/Http/Controllers/'.$names['controllerName'].'.php';
+        $writer->write($path, $controllerContent, $force);
+        $this->info('Controller created: '.$path);
+    }
+
+    private function generateViews(FileWriter $writer, array $names, array $fields, bool $force): void
+    {
+        $viewsDir = 'resources/views/'.$names['viewDir'];
+        $paramVar = $names['singularSnake'];
+
+        $formFields = [];
+        foreach ($fields as $field) {
+            $label = Str::title(str_replace('_', ' ', $field['name']));
+            $input = $this->inputForType($field['name'], $field['type']);
+            $formFields[] = "    <div>\n        <label>{$label}</label><br>\n        {$input}\n    </div>";
+        }
+
+        $index = <<<BLADE
+<h1>{$names['modelName']} List</h1>
+<p><a href="{{ route('{$names['routeName']}.create') }}">Create</a></p>
+@if(session('status'))<div>{{ session('status') }}</div>@endif
+<table border="1" cellpadding="6" cellspacing="0">
+    <thead>
+        <tr>
+            <th>ID</th>
+BLADE;
+        foreach ($fields as $field) {
+            $index .= "            <th>".Str::title(str_replace('_',' ', $field['name']))."</th>\n";
+        }
+        $index .= "            <th>Actions</th>\n        </tr>\n    </thead>\n    <tbody>\n    @foreach(\$items as \$item)\n        <tr>\n            <td>{{ \$item->id }}</td>\n";
+        foreach ($fields as $field) {
+            $index .= "            <td>{{ \$item->{$field['name']} }}</td>\n";
+        }
+        $index .= "            <td>\n                <a href=\"{{ route('{$names['routeName']}.show', \$item) }}\">Show</a> |\n                <a href=\"{{ route('{$names['routeName']}.edit', \$item) }}\">Edit</a> |\n                <form method=\"POST\" action=\"{{ route('{$names['routeName']}.destroy', \$item) }}\" style=\"display:inline\">\n                    @csrf @method('DELETE')\n                    <button type=\"submit\" onclick=\"return confirm('Delete?')\">Delete</button>\n                </form>\n            </td>\n        </tr>\n    @endforeach\n    </tbody>\n</table>\n{{ \$items->links() }}\n";
+
+        $create = <<<BLADE
+<h1>Create {$names['modelName']}</h1>
+<form method="POST" action="{{ route('{$names['routeName']}.store') }}">
+    @csrf
+{$this->implodeLines($formFields)}
+    <button type="submit">Save</button>
+</form>
+BLADE;
+
+        $editFields = [];
+        foreach ($fields as $field) {
+            $label = Str::title(str_replace('_', ' ', $field['name']));
+            $valueBinding = "{{ old('{$field['name']}', \${$paramVar}->{$field['name']}) }}";
+            $editFields[] = "    <div>\n        <label>{$label}</label><br>\n        ".$this->inputForType($field['name'], $field['type'], $valueBinding)."\n    </div>";
+        }
+
+        $edit = <<<BLADE
+<h1>Edit {$names['modelName']}</h1>
+<form method="POST" action="{{ route('{$names['routeName']}.update', \${$paramVar}) }}">
+    @csrf
+    @method('PUT')
+{$this->implodeLines($editFields)}
+    <button type="submit">Update</button>
+</form>
+BLADE;
+
+        $showRows = [];
+        foreach ($fields as $field) {
+            $label = Str::title(str_replace('_', ' ', $field['name']));
+            $showRows[] = "    <tr><th>{$label}</th><td>{{ \\${$paramVar}->{$field['name']} }}</td></tr>";
+        }
+
+        $show = <<<BLADE
+<h1>Show {$names['modelName']}</h1>
+<table border="1" cellpadding="6" cellspacing="0">
+{$this->implodeLines($showRows)}
+</table>
+BLADE;
+
+        $writer->write($viewsDir.'/index.blade.php', $index, $force);
+        $writer->write($viewsDir.'/create.blade.php', $create, $force);
+        $writer->write($viewsDir.'/edit.blade.php', $edit, $force);
+        $writer->write($viewsDir.'/show.blade.php', $show, $force);
+        $this->info('Views created in: '.$viewsDir);
+    }
+
+    private function updateRoutes(FileWriter $writer, array $names, bool $isApi): void
+    {
+        $routeFile = $isApi ? 'routes/api.php' : 'routes/web.php';
+        $routeResource = $isApi
+            ? "Route::apiResource('{$names['routeUri']}', \\App\\Http\\Controllers\\{$names['controllerName']}::class);"
+            : "Route::resource('{$names['routeUri']}', \\App\\Http\\Controllers\\{$names['controllerName']}::class);";
+
+        $append = $routeResource."\n";
+
+        $writer->appendOnce($routeFile, $append, $names['controllerName']);
+        $this->info('Routes updated: '.$routeFile.' (resource: '.$names['routeName'].')');
+    }
+
+    private function columnForField(array $field): string
+    {
+        $name = $field['name'];
+        $type = $field['type'];
+        return match ($type) {
+            'id', 'bigint', 'unsignedBigInteger' => "\$table->unsignedBigInteger('{$name}');",
+            'string' => "\$table->string('{$name}');",
+            'text' => "\$table->text('{$name}');",
+            'integer' => "\$table->integer('{$name}');",
+            'bigInteger' => "\$table->bigInteger('{$name}');",
+            'boolean' => "\$table->boolean('{$name}');",
+            'date' => "\$table->date('{$name}');",
+            'datetime', 'timestamp' => "\$table->dateTime('{$name}');",
+            'decimal' => "\$table->decimal('{$name}', 10, 2);",
+            default => "\$table->string('{$name}');",
+        };
+    }
+
+    private function validationForType(string $type): string
+    {
+        return match ($type) {
+            'text' => 'required|string',
+            'string' => 'required|string|max:255',
+            'integer', 'bigInteger' => 'required|integer',
+            'boolean' => 'required|boolean',
+            'date' => 'required|date',
+            'datetime', 'timestamp' => 'required|date',
+            'decimal' => 'required|numeric',
+            default => 'required',
+        };
+    }
+
+    private function inputForType(string $name, string $type, string $valueBinding = null): string
+    {
+        $value = $valueBinding ? $valueBinding : "{{ old('{$name}') }}";
+        return match ($type) {
+            'text' => "<textarea name=\"{$name}\">{$value}</textarea>",
+            'boolean' => "<input type=\"checkbox\" name=\"{$name}\" value=\"1\" {{ old('{$name}') ? 'checked' : '' }}>",
+            'date' => "<input type=\"date\" name=\"{$name}\" value=\"{$value}\">",
+            'datetime', 'timestamp' => "<input type=\"datetime-local\" name=\"{$name}\" value=\"{$value}\">",
+            'integer', 'bigInteger', 'decimal' => "<input type=\"number\" name=\"{$name}\" value=\"{$value}\">",
+            default => "<input type=\"text\" name=\"{$name}\" value=\"{$value}\">",
+        };
+    }
+
+    private function implodeIndented(array $items, string $indent = '        '): string
+    {
+        return implode(",\n{$indent}", $items);
+    }
+
+    private function implodeLines(array $lines): string
+    {
+        return implode("\n", $lines);
+    }
+}

--- a/src/ScaffoldAgentServiceProvider.php
+++ b/src/ScaffoldAgentServiceProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Acme\ScaffoldAgent;
+
+use Illuminate\Support\ServiceProvider;
+
+class ScaffoldAgentServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                \Acme\ScaffoldAgent\Console\ScaffoldModuleCommand::class,
+            ]);
+        }
+    }
+}

--- a/src/Support/FileWriter.php
+++ b/src/Support/FileWriter.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Acme\ScaffoldAgent\Support;
+
+use Illuminate\Filesystem\Filesystem;
+
+class FileWriter
+{
+    private Filesystem $files;
+    private string $basePath;
+
+    public function __construct(string $basePath)
+    {
+        $this->files = new Filesystem();
+        $this->basePath = rtrim($basePath, '/');
+    }
+
+    public function write(string $relativePath, string $contents, bool $force = false): void
+    {
+        $path = $this->path($relativePath);
+        $dir = dirname($path);
+        if (!$this->files->exists($dir)) {
+            $this->files->makeDirectory($dir, 0755, true);
+        }
+        if ($this->files->exists($path) && !$force) {
+            return; // do not overwrite
+        }
+        $this->files->put($path, $contents);
+    }
+
+    public function appendOnce(string $relativePath, string $append, string $uniqueKey): void
+    {
+        $path = $this->path($relativePath);
+        if (!$this->files->exists($path)) {
+            $this->write($relativePath, "<?php\n\n".$append, true);
+            return;
+        }
+        $current = $this->files->get($path);
+        if (str_contains($current, $uniqueKey)) {
+            return; // already added
+        }
+        $this->files->append($path, "\n".$append);
+    }
+
+    private function path(string $relativePath): string
+    {
+        return $this->basePath.'/'.$relativePath;
+    }
+}

--- a/src/Support/NameInflector.php
+++ b/src/Support/NameInflector.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Acme\ScaffoldAgent\Support;
+
+use Illuminate\Support\Str;
+
+class NameInflector
+{
+    private string $base;
+
+    public function __construct(string $baseName)
+    {
+        $this->base = Str::studly(Str::singular($baseName));
+    }
+
+    public function toArray(): array
+    {
+        $modelName = $this->base;
+        $controllerName = $modelName.'Controller';
+        $singularSnake = Str::snake($modelName);
+        $pluralSnake = Str::snake(Str::pluralStudly($modelName));
+        $routeName = Str::kebab(Str::pluralStudly($modelName));
+        $routeUri = Str::kebab(Str::pluralStudly($modelName));
+        $viewDir = Str::kebab($modelName);
+        $tableName = $pluralSnake;
+
+        return [
+            'modelName' => $modelName,
+            'controllerName' => $controllerName,
+            'singularSnake' => $singularSnake,
+            'pluralSnake' => $pluralSnake,
+            'routeName' => $routeName,
+            'routeUri' => $routeUri,
+            'viewDir' => $viewDir,
+            'tableName' => $tableName,
+        ];
+    }
+}

--- a/src/Support/PromptParser.php
+++ b/src/Support/PromptParser.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Acme\ScaffoldAgent\Support;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Http;
+
+class PromptParser
+{
+    /**
+     * Parse prompt and/or explicit options into a spec:
+     * [ 'name' => string, 'fields' => [ ['name'=>string,'type'=>string], ... ] ]
+     */
+    public function parse(string $prompt, array $options = []): ?array
+    {
+        $name = $options['name'] ?? null;
+        $fieldsLine = $options['fields'] ?? null;
+
+        if ($fieldsLine) {
+            $fields = $this->parseFieldsList($fieldsLine);
+        }
+
+        if (!$name || empty($fields)) {
+            $fromPrompt = $this->parseWithLLMOrHeuristics($prompt);
+            if ($fromPrompt) {
+                $name = $name ?: ($fromPrompt['name'] ?? null);
+                $fields = !empty($fields) ? $fields : ($fromPrompt['fields'] ?? []);
+            }
+        }
+
+        if (!$name || empty($fields)) {
+            return null;
+        }
+
+        // Normalize
+        $name = Str::of($name)->snake('-')->replace('-', ' ')->trim()->explode(' ')->first();
+        $name = Str::singular((string) $name);
+
+        $normalizedFields = [];
+        foreach ($fields as $field) {
+            $fname = Str::snake($field['name']);
+            $ftype = strtolower($field['type'] ?? 'string');
+            $normalizedFields[] = [
+                'name' => $fname,
+                'type' => $this->normalizeType($fname, $ftype),
+            ];
+        }
+
+        return [
+            'name' => $name,
+            'fields' => $normalizedFields,
+        ];
+    }
+
+    private function parseFieldsList(string $line): array
+    {
+        $parts = array_filter(array_map('trim', explode(',', $line)));
+        $fields = [];
+        foreach ($parts as $part) {
+            if (str_contains($part, ':')) {
+                [$n, $t] = array_map('trim', explode(':', $part, 2));
+                $fields[] = ['name' => $n, 'type' => $t];
+            } else {
+                $fields[] = ['name' => $part, 'type' => $this->guessType($part)];
+            }
+        }
+        return $fields;
+    }
+
+    private function parseWithLLMOrHeuristics(string $prompt): ?array
+    {
+        $prompt = trim($prompt);
+        if ($prompt === '') {
+            return null;
+        }
+
+        $apiKey = env('OPENAI_API_KEY');
+        if ($apiKey) {
+            try {
+                $resp = Http::withToken($apiKey)
+                    ->timeout(15)
+                    ->post('https://api.openai.com/v1/chat/completions', [
+                        'model' => env('OPENAI_MODEL', 'gpt-4o-mini'),
+                        'messages' => [
+                            [
+                                'role' => 'system',
+                                'content' => 'You extract a Laravel module spec from a prompt. Respond as strict JSON with keys: name (singular), fields (array of {name,type}). Types are one of: string,text,integer,bigInteger,boolean,date,datetime,timestamp,decimal.'
+                            ],
+                            [ 'role' => 'user', 'content' => $prompt ],
+                        ],
+                        'temperature' => 0.2,
+                    ]);
+                if ($resp->successful()) {
+                    $json = $resp->json('choices.0.message.content');
+                    $data = json_decode($json, true);
+                    if (is_array($data) && !empty($data['name']) && !empty($data['fields'])) {
+                        return $data;
+                    }
+                }
+            } catch (\Throwable $e) {
+                // fall through to heuristics
+            }
+        }
+
+        // Heuristic parsing: "Create a blog module with title, content, published_at"
+        $name = null;
+        $fields = [];
+
+        $lower = strtolower($prompt);
+        // Find name near "create a <name> module"
+        if (preg_match('/create\s+(?:an?\s+)?([a-z0-9_\-]+)\s+module/i', $prompt, $m)) {
+            $name = $m[1];
+        }
+        // Find fields after "with ..." or "having ..."
+        if (preg_match('/(?:with|having)\s+([a-z0-9_,\s:\-]+)/i', $prompt, $m2)) {
+            $fieldsLine = trim($m2[1]);
+            $fields = $this->parseFieldsList($fieldsLine);
+        }
+
+        if (!$name) {
+            // fallback: first word
+            $tokens = preg_split('/\s+/', trim($prompt));
+            $name = $tokens[0] ?? 'item';
+        }
+        if (empty($fields)) {
+            // fallback: guess from text commas
+            $tokens = [];
+            if (preg_match_all('/([a-zA-Z_][a-zA-Z0-9_]*)(?=,|\s|$)/', $prompt, $mm)) {
+                foreach ($mm[1] as $t) {
+                    if (!in_array(strtolower($t), ['create','module','with','having','and'])) {
+                        $tokens[] = $t;
+                    }
+                }
+            }
+            $tokens = array_slice($tokens, 1, 5);
+            foreach ($tokens as $t) {
+                $fields[] = ['name' => $t, 'type' => $this->guessType($t)];
+            }
+        }
+
+        if ($name && !empty($fields)) {
+            return [ 'name' => $name, 'fields' => $fields ];
+        }
+        return null;
+    }
+
+    private function normalizeType(string $name, string $type): string
+    {
+        $type = strtolower($type);
+        return match (true) {
+            str_ends_with($name, '_id') => 'unsignedBigInteger',
+            str_ends_with($name, '_at') => 'datetime',
+            in_array($type, ['string','text','integer','biginteger','boolean','date','datetime','timestamp','decimal']) => $type === 'biginteger' ? 'bigInteger' : $type,
+            default => $this->guessType($name),
+        };
+    }
+
+    private function guessType(string $name): string
+    {
+        $lname = strtolower($name);
+        return match (true) {
+            str_contains($lname, 'content') || str_contains($lname, 'body') || str_contains($lname, 'description') => 'text',
+            str_ends_with($lname, '_id') => 'unsignedBigInteger',
+            str_ends_with($lname, '_at') => 'datetime',
+            str_starts_with($lname, 'is_') || str_starts_with($lname, 'has_') => 'boolean',
+            default => 'string',
+        };
+    }
+}

--- a/tests/ScaffoldModuleCommandTest.php
+++ b/tests/ScaffoldModuleCommandTest.php
@@ -1,0 +1,5 @@
+<?php
+
+it('placeholder', function () {
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
Adds a Laravel Artisan command to generate full CRUD modules (Models, Migrations, Controllers, Routes, Views) from a natural language prompt.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e8180e5-c0f0-4d82-89f3-3aac62f06f81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e8180e5-c0f0-4d82-89f3-3aac62f06f81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

